### PR TITLE
feat(module1): allow provided config object to extend other configs

### DIFF
--- a/modules/module1/outputs.tf
+++ b/modules/module1/outputs.tf
@@ -25,3 +25,7 @@ output "output5" {
 output "output6" {
   value = var.input6
 }
+
+output "output7" {
+  value = var.input7
+}

--- a/modules/module1/vars.tf
+++ b/modules/module1/vars.tf
@@ -33,3 +33,9 @@ variable "input6" {
   description = "Input variable for module1"
   default     = "value6"
 }
+
+variable "input7" {
+  type        = string
+  description = "Input variable for module1"
+  default     = "value7"
+}


### PR DESCRIPTION
BREAKING CHANGE: `extends` key in config file is now used for extending other config files